### PR TITLE
Cast duration to int to fix update crash

### DIFF
--- a/api/scripts/create_csv.py
+++ b/api/scripts/create_csv.py
@@ -26,7 +26,7 @@ try:
         uploaded = data['upload_date']
         thumbnail = data['thumbnail'].replace('maxresdefault.jpg', 'sddefault.jpg')
         title = data['fulltitle']
-        length = data['duration']
+        length = int(data['duration'])
         info_writer.writerow([id,title,length,thumbnail,uploaded])
       # captions
       


### PR DESCRIPTION
Youtube (or youtube_dl?) changed the json format for the duration of a video to be a double instead of int which was causing updating to crash when trying to insert a non-integer into and integer field in the DB.
![image](https://user-images.githubusercontent.com/58332164/104845955-677a7600-591b-11eb-944b-3ddd68e2eb3d.png)

This converts the duration to an int so it can be inserted correctly.